### PR TITLE
feat: JWT 인증 기반 사용자별 포트폴리오 격리 및 다수 버그 수정

### DIFF
--- a/backend/src/main/java/com/portfolio/api/AuthController.java
+++ b/backend/src/main/java/com/portfolio/api/AuthController.java
@@ -1,10 +1,16 @@
 package com.portfolio.api;
 
+import com.portfolio.auth.entity.User;
+import com.portfolio.auth.jwt.JwtTokenProvider;
+import com.portfolio.auth.repository.UserRepository;
 import com.portfolio.auth.service.AuthService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -16,6 +22,8 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request) {
@@ -73,17 +81,94 @@ public class AuthController {
         }
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<?> me() {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null || !authentication.isAuthenticated()
+                    || "anonymousUser".equals(authentication.getPrincipal())) {
+                return createAuthErrorResponse("Not authenticated", HttpStatus.UNAUTHORIZED);
+            }
+
+            String email;
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof UserDetails) {
+                email = ((UserDetails) principal).getUsername();
+            } else {
+                email = principal.toString();
+            }
+
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+            Map<String, Object> userData = new HashMap<>();
+            userData.put("id", user.getId());
+            userData.put("email", user.getEmail());
+            userData.put("displayName", user.getDisplayName());
+            userData.put("locale", user.getLocale());
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("data", userData);
+            response.put("meta", Map.of("timestamp", java.time.Instant.now().toString()));
+            response.put("error", null);
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return createAuthErrorResponse("Not authenticated", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(@RequestBody RefreshRequest request) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("accessToken", "mock-access-token-" + System.currentTimeMillis());
-        
-        return ResponseEntity.ok(response);
+        try {
+            String refreshToken = request.getRefreshToken();
+            if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+                return createAuthErrorResponse("Invalid refresh token", HttpStatus.UNAUTHORIZED);
+            }
+
+            String email = jwtTokenProvider.getUsername(refreshToken);
+            // 사용자가 존재하는지 확인
+            userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+            String newAccessToken = jwtTokenProvider.generateAccessToken(email);
+            String newRefreshToken = jwtTokenProvider.generateRefreshToken(email);
+
+            Map<String, Object> tokenData = new HashMap<>();
+            tokenData.put("accessToken", newAccessToken);
+            tokenData.put("refreshToken", newRefreshToken);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("data", tokenData);
+            response.put("meta", Map.of("timestamp", java.time.Instant.now().toString()));
+            response.put("error", null);
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return createAuthErrorResponse("Failed to refresh token", HttpStatus.UNAUTHORIZED);
+        }
     }
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout() {
-        return ResponseEntity.ok(Map.of("message", "Logged out successfully"));
+        Map<String, Object> response = new HashMap<>();
+        response.put("data", Map.of("message", "Logged out successfully"));
+        response.put("meta", Map.of("timestamp", java.time.Instant.now().toString()));
+        response.put("error", null);
+        return ResponseEntity.ok(response);
+    }
+
+    private ResponseEntity<?> createAuthErrorResponse(String message, HttpStatus status) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("code", "AUTH_FAILED");
+        error.put("message", message);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("data", null);
+        response.put("meta", Map.of("timestamp", java.time.Instant.now().toString()));
+        response.put("error", error);
+
+        return ResponseEntity.status(status).body(response);
     }
 
     @Data

--- a/backend/src/main/java/com/portfolio/api/RebalanceController.java
+++ b/backend/src/main/java/com/portfolio/api/RebalanceController.java
@@ -1,7 +1,7 @@
 package com.portfolio.api;
 
 import com.portfolio.common.exception.BusinessException;
-import com.portfolio.infra.init.DataInitializer;
+import com.portfolio.common.util.SecurityUtils;
 import com.portfolio.rebalance.service.RebalanceService;
 import com.portfolio.rebalance.service.RebalanceService.RebalanceAnalysis;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +23,13 @@ import java.util.Map;
 public class RebalanceController {
 
     private final RebalanceService rebalanceService;
-
-    private static final String DEFAULT_WORKSPACE_ID = DataInitializer.DEFAULT_WORKSPACE_ID;
+    private final SecurityUtils securityUtils;
 
     @GetMapping("/{id}/rebalance")
     public ResponseEntity<?> getRebalanceAnalysis(@PathVariable String id) {
         try {
-            RebalanceAnalysis analysis = rebalanceService.analyze(id, DEFAULT_WORKSPACE_ID);
+            String workspaceId = securityUtils.getCurrentWorkspaceId();
+            RebalanceAnalysis analysis = rebalanceService.analyze(id, workspaceId);
 
             Map<String, Object> response = new HashMap<>();
             response.put("data", analysis);

--- a/backend/src/main/java/com/portfolio/api/ValuationController.java
+++ b/backend/src/main/java/com/portfolio/api/ValuationController.java
@@ -3,7 +3,7 @@ package com.portfolio.api;
 import com.portfolio.analytics.service.PerformanceService;
 import com.portfolio.analytics.service.PerformanceService.PerformanceResult;
 import com.portfolio.common.exception.BusinessException;
-import com.portfolio.infra.init.DataInitializer;
+import com.portfolio.common.util.SecurityUtils;
 import com.portfolio.portfolio.service.PortfolioService;
 import com.portfolio.valuation.service.ValuationService;
 import com.portfolio.valuation.service.ValuationService.PortfolioValuation;
@@ -26,8 +26,7 @@ public class ValuationController {
     private final PortfolioService portfolioService;
     private final ValuationService valuationService;
     private final PerformanceService performanceService;
-
-    private static final String DEFAULT_WORKSPACE_ID = DataInitializer.DEFAULT_WORKSPACE_ID;
+    private final SecurityUtils securityUtils;
 
     /**
      * 포트폴리오 평가액 조회
@@ -38,7 +37,8 @@ public class ValuationController {
             @PathVariable String id,
             @RequestParam(defaultValue = "REALTIME") String mode) {
         try {
-            PortfolioValuation valuation = valuationService.calculateValuation(id, DEFAULT_WORKSPACE_ID);
+            String workspaceId = securityUtils.getCurrentWorkspaceId();
+            PortfolioValuation valuation = valuationService.calculateValuation(id, workspaceId);
 
             Map<String, Object> data = new LinkedHashMap<>();
             data.put("portfolioId", valuation.portfolioId);
@@ -80,8 +80,9 @@ public class ValuationController {
             @RequestParam(defaultValue = "TWR") String metric,
             @RequestParam(defaultValue = "DAILY") String frequency) {
         try {
+            String workspaceId = securityUtils.getCurrentWorkspaceId();
             PerformanceResult result = performanceService.calculatePerformance(
-                    id, DEFAULT_WORKSPACE_ID,
+                    id, workspaceId,
                     LocalDate.parse(from), LocalDate.parse(to),
                     metric, frequency);
 

--- a/backend/src/main/java/com/portfolio/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/portfolio/auth/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.portfolio.auth.config;
 
+import com.portfolio.auth.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -8,29 +10,38 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()  // 개발 모드: 모든 요청 허용
-                );
+                        .requestMatchers("/v1/auth/login", "/v1/auth/register", "/v1/auth/refresh").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -39,7 +50,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(List.of(
-                "http://localhost:5173", 
+                "http://localhost:5173",
                 "http://localhost:5174",
                 "http://localhost:3000"
         ));

--- a/backend/src/main/java/com/portfolio/common/util/SecurityUtils.java
+++ b/backend/src/main/java/com/portfolio/common/util/SecurityUtils.java
@@ -1,0 +1,57 @@
+package com.portfolio.common.util;
+
+import com.portfolio.auth.entity.User;
+import com.portfolio.auth.repository.UserRepository;
+import com.portfolio.workspace.entity.Workspace;
+import com.portfolio.workspace.service.WorkspaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증된 사용자 정보 및 workspace 조회 유틸리티
+ */
+@Component
+@RequiredArgsConstructor
+public class SecurityUtils {
+
+    private final UserRepository userRepository;
+    private final WorkspaceService workspaceService;
+
+    /**
+     * 현재 인증된 사용자의 이메일을 가져옵니다.
+     */
+    public String getCurrentUserEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            throw new IllegalStateException("Not authenticated");
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails) {
+            return ((UserDetails) principal).getUsername();
+        }
+        return principal.toString();
+    }
+
+    /**
+     * 현재 인증된 사용자의 User 엔티티를 가져옵니다.
+     */
+    public User getCurrentUser() {
+        String email = getCurrentUserEmail();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + email));
+    }
+
+    /**
+     * 현재 인증된 사용자의 기본 workspace ID를 가져옵니다.
+     */
+    public String getCurrentWorkspaceId() {
+        User user = getCurrentUser();
+        Workspace workspace = workspaceService.getDefaultWorkspace(user.getId());
+        return workspace.getId();
+    }
+}

--- a/backend/src/main/java/com/portfolio/valuation/service/ValuationService.java
+++ b/backend/src/main/java/com/portfolio/valuation/service/ValuationService.java
@@ -114,11 +114,12 @@ public class ValuationService {
 
         BigDecimal totalValue = totalAssetValue.add(cashBalance);
 
-        // 비중 계산
+        // 비중 계산 (자산 시가 총합 기반 - 음수 총가치 방지)
+        BigDecimal weightBase = totalAssetValue.abs().compareTo(BigDecimal.ZERO) > 0
+                ? totalAssetValue.abs()
+                : BigDecimal.ONE;
         for (PositionValuation pv : positions) {
-            pv.weight = totalValue.compareTo(BigDecimal.ZERO) > 0
-                    ? pv.marketValueBase.divide(totalValue, 6, RoundingMode.HALF_UP)
-                    : BigDecimal.ZERO;
+            pv.weight = pv.marketValueBase.abs().divide(weightBase, 6, RoundingMode.HALF_UP);
         }
 
         // 전체 손익

--- a/frontend/src/api/instrument.ts
+++ b/frontend/src/api/instrument.ts
@@ -23,17 +23,17 @@ export interface InstrumentSearchParams {
 
 export const instrumentApi = {
   async search(params: InstrumentSearchParams) {
-    const response = await apiClient.get('/instruments/search', { params });
+    const response = await apiClient.get('/v1/instruments/search', { params });
     return response.data;
   },
 
   async getById(id: string) {
-    const response = await apiClient.get(`/instruments/${id}`);
+    const response = await apiClient.get(`/v1/instruments/${id}`);
     return response.data;
   },
 
   async getAll(assetClass?: string) {
-    const response = await apiClient.get('/instruments', {
+    const response = await apiClient.get('/v1/instruments', {
       params: { assetClass },
     });
     return response.data;

--- a/frontend/src/components/portfolio/TargetWeights.vue
+++ b/frontend/src/components/portfolio/TargetWeights.vue
@@ -193,7 +193,7 @@ onMounted(() => {
                   placeholder="Cash"
                   class="input-sm"
                 />
-                <span v-else>{{ target.instrumentId }}</span>
+                <span v-else>{{ target.ticker || target.instrumentName || target.instrumentId }}</span>
               </td>
               <td>
                 <select v-model="target.assetClass" class="select-sm">

--- a/frontend/src/components/portfolio/TransactionList.vue
+++ b/frontend/src/components/portfolio/TransactionList.vue
@@ -186,12 +186,12 @@ defineExpose({ refresh: fetchTransactions });
           <td class="date-cell">{{ dayjs(tx.occurredAt).format('YYYY-MM-DD') }}</td>
           <td>
             <span class="type-badge" :style="{ color: typeColors[tx.type] || '#64748b' }">
-              {{ getTypeLabel(tx.type) }}
+              {{ typeLabels[tx.type] || tx.type }}
             </span>
           </td>
           <td>
             <template v-if="getMainLeg(tx)?.instrumentId">
-              {{ getMainLeg(tx)?.instrumentId }}
+              {{ getMainLeg(tx)?.ticker || getMainLeg(tx)?.instrumentName || getMainLeg(tx)?.instrumentId }}
             </template>
             <span v-else class="text-muted">-</span>
           </td>

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -13,6 +13,8 @@ export default {
     success: 'Success',
     confirm: 'Confirm',
     retry: 'Retry',
+    saving: 'Saving...',
+    actions: 'Actions',
   },
   nav: {
     dashboard: 'Dashboard',

--- a/frontend/src/locales/ko.ts
+++ b/frontend/src/locales/ko.ts
@@ -13,6 +13,8 @@ export default {
     success: '성공',
     confirm: '확인',
     retry: '다시 시도',
+    saving: '저장 중...',
+    actions: '작업',
   },
   nav: {
     dashboard: '대시보드',

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -3,8 +3,28 @@ import { ref, computed } from 'vue';
 import { authApi, type LoginRequest, type RegisterRequest } from '@/api';
 import type { User } from '@/types';
 
+const USER_STORAGE_KEY = 'user';
+
+function saveUserToStorage(userData: User | null) {
+  if (userData) {
+    localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(userData));
+  } else {
+    localStorage.removeItem(USER_STORAGE_KEY);
+  }
+}
+
+function loadUserFromStorage(): User | null {
+  try {
+    const stored = localStorage.getItem(USER_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : null;
+  } catch {
+    return null;
+  }
+}
+
 export const useAuthStore = defineStore('auth', () => {
-  const user = ref<User | null>(null);
+  // 초기화 시 localStorage에서 user 정보를 복구
+  const user = ref<User | null>(loadUserFromStorage());
   const loading = ref(false);
   const error = ref<string | null>(null);
 
@@ -18,6 +38,7 @@ export const useAuthStore = defineStore('auth', () => {
       user.value = response.user;
       localStorage.setItem('accessToken', response.tokens.accessToken);
       localStorage.setItem('refreshToken', response.tokens.refreshToken);
+      saveUserToStorage(response.user);
       return response;
     } catch (e: unknown) {
       error.value = (e as Error).message || 'Login failed';
@@ -35,6 +56,7 @@ export const useAuthStore = defineStore('auth', () => {
       user.value = response.user;
       localStorage.setItem('accessToken', response.tokens.accessToken);
       localStorage.setItem('refreshToken', response.tokens.refreshToken);
+      saveUserToStorage(response.user);
       return response;
     } catch (e: unknown) {
       error.value = (e as Error).message || 'Registration failed';
@@ -46,13 +68,28 @@ export const useAuthStore = defineStore('auth', () => {
 
   async function fetchUser() {
     const token = localStorage.getItem('accessToken');
-    if (!token) return;
+    if (!token) {
+      // 토큰 없으면 저장된 user도 지움
+      user.value = null;
+      saveUserToStorage(null);
+      return;
+    }
 
     loading.value = true;
     try {
-      user.value = await authApi.me();
+      const userData = await authApi.me();
+      user.value = userData;
+      saveUserToStorage(userData);
     } catch {
-      logout();
+      // /me 실패 시, localStorage에 user 정보가 있으면 유지 (토큰 갱신 시도)
+      const storedUser = loadUserFromStorage();
+      if (storedUser && localStorage.getItem('refreshToken')) {
+        // refresh token이 있으면 user 정보는 유지하고,
+        // 다음 API 호출에서 interceptor가 토큰을 갱신할 것
+        user.value = storedUser;
+      } else {
+        logout();
+      }
     } finally {
       loading.value = false;
     }
@@ -62,6 +99,7 @@ export const useAuthStore = defineStore('auth', () => {
     user.value = null;
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
+    saveUserToStorage(null);
   }
 
   return {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,6 +48,8 @@ export interface Portfolio {
 export interface PortfolioTarget {
   id: string;
   instrumentId?: string;
+  ticker?: string;
+  instrumentName?: string;
   assetClass: AssetClass;
   currency?: string;
   targetWeight: number;
@@ -92,6 +94,8 @@ export interface TransactionLeg {
   id?: string;
   legType: LegType;
   instrumentId?: string;
+  ticker?: string;
+  instrumentName?: string;
   currency: string;
   quantity?: number;
   price?: number;

--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -248,7 +248,7 @@ function navigateToPortfolio(id: string) {
               <td class="text-muted">{{ formatDate(tx.occurredAt) }}</td>
               <td>{{ tx.portfolioName }}</td>
               <td><span class="type-badge" :class="getTypeBadgeClass(tx.type)">{{ typeLabels[tx.type] || tx.type }}</span></td>
-              <td>{{ getMainLeg(tx)?.instrumentId || '-' }}</td>
+              <td>{{ getMainLeg(tx)?.ticker || getMainLeg(tx)?.instrumentName || '-' }}</td>
               <td class="text-right font-mono">
                 {{ formatCurrency(Math.abs(getMainLeg(tx)?.amount || 0), 'KRW') }}
               </td>


### PR DESCRIPTION
- SecurityConfig: JWT 필터 등록, 인증 필수화 (login/register/refresh만 permitAll)
- AuthController: /me 엔드포인트 추가, /refresh 토큰 갱신 정상 구현
- SecurityUtils: 인증된 사용자의 workspace ID 조회 공통 유틸리티
- 모든 Controller(Portfolio, Transaction, Valuation, Compare, Rebalance, PortfolioGroup)에서 하드코딩된 DEFAULT_WORKSPACE_ID 제거 → 인증된 사용자의 workspace 기반 필터링
- auth store: localStorage에 user 정보 영속화하여 캐시비우기 시 로그아웃 방지
- instrument.ts: API 경로 /v1 접두사 누락 수정
- TransactionList.vue: getTypeLabel 미정의 함수 버그 수정
- TargetWeights.vue: 종목 UUID 대신 ticker/name 표시
- PortfolioController: target DTO에 ticker/instrumentName 추가
- ValuationService: weight 계산 시 절대값 기반으로 수정
- DashboardView: 최근거래 종목명 표시 개선
- i18n: common.actions, common.saving 키 추가
- types: PortfolioTarget, TransactionLeg에 ticker/instrumentName 필드 추가