### PR TITLE
chore: 크로스플랫폼(Mac/Windows) .gitignore 및 .gitattributes 설정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,62 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Shell scripts must use LF (Unix)
+*.sh text eol=lf
+gradlew text eol=lf
+
+# Batch scripts must use CRLF (Windows)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Source code (force LF for consistency)
+*.java text eol=lf
+*.kt text eol=lf
+*.groovy text eol=lf
+*.gradle text eol=lf
+*.kts text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.properties text eol=lf
+*.sql text eol=lf
+
+# Frontend source (force LF)
+*.js text eol=lf
+*.ts text eol=lf
+*.vue text eol=lf
+*.jsx text eol=lf
+*.tsx text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+
+# Config files
+*.toml text eol=lf
+*.ini text eol=lf
+*.cfg text eol=lf
+*.conf text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf
+.editorconfig text eol=lf
+Dockerfile text eol=lf
+docker-compose*.yml text eol=lf
+
+# Binary files (no line ending conversion)
+*.jar binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,35 @@
-# IDE
+# === IDE ===
 .idea/
 *.iml
 .vscode/
+*.swp
+*.swo
+*~
 
-# OS
+# === OS (Mac / Windows / Linux) ===
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
 Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
 
-# Backend
+# === Backend ===
 backend/build/
 backend/.gradle/
 backend/out/
 
-# Frontend
+# === Frontend ===
 frontend/node_modules/
 frontend/dist/
 
-# Env
+# === Environment ===
 .env
-.env.local
+.env.*
+!.env.example

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,6 +38,14 @@ out/
 
 ### Mac ###
 .DS_Store
+._*
+
+### Windows ###
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
 
 ### Logs ###
 logs/
@@ -45,4 +53,5 @@ logs/
 
 ### Environment ###
 .env
-.env.local
+.env.*
+!.env.example

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -16,9 +16,22 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
-.DS_Store
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+._*
+Thumbs.db
+Desktop.ini
+
+# Environment
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
## Summary
- `.gitignore` 보강: Windows(Thumbs.db, Desktop.ini 등) 및 Mac(._*, .Spotlight-V100 등) OS 파일 무시 패턴 추가
- `.gitattributes` 신규 생성: 줄바꿈 자동 정규화(LF)로 Mac/Windows 간 CRLF 충돌 방지
- `.env.*` 패턴으로 환경파일 일괄 무시 (`.env.example`만 허용)

## Test plan
- [ ] Mac에서 clone/pull 후 줄바꿈 문제 없는지 확인
- [ ] Windows에서 clone/pull 후 줄바꿈 문제 없는지 확인
- [ ] `gradlew`(LF), `gradlew.bat`(CRLF) 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)