### PR TITLE
chore(config): separate external API keys into ignored local properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ frontend/dist/
 .env
 .env.*
 !.env.example
+
+# Private API key files
+backend/src/main/resources/api-keys.yml

--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ cd backend
 백엔드 서버: http://localhost:8080/api
 Swagger UI: http://localhost:8080/api/swagger-ui.html
 
+### 외부 시세 API 연동 (Alpha Vantage / KRX)
+
+백엔드는 기본적으로 Mock 시세를 사용하며, 아래 환경변수를 설정하면 외부 API 연동을 활성화할 수 있습니다.
+
+```bash
+export EXTERNAL_PRICING_ENABLED=true
+# 방법 1) 환경변수
+export ALPHA_VANTAGE_API_KEY=your_api_key
+
+# 방법 2) 로컬 파일 (gitignore 처리됨)
+cp backend/src/main/resources/api-keys.example.yml backend/src/main/resources/api-keys.yml
+# api-keys.yml 의 api.keys.alpha-vantage 값을 실제 키로 교체
+
+# 선택: 커스텀 엔드포인트
+# export ALPHA_VANTAGE_BASE_URL=https://www.alphavantage.co
+# export KRX_BASE_URL=http://data.krx.co.kr
+```
+
+- 해외/환율: Alpha Vantage
+- 국내(한국 종목): KRX 정보데이터시스템
+- 외부 API 실패 시 Mock 가격으로 자동 폴백
+
+
 #### 4. 프론트엔드 실행
 
 ```bash

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -55,3 +55,6 @@ logs/
 .env
 .env.*
 !.env.example
+
+# Private API key files
+src/main/resources/api-keys.yml

--- a/backend/src/main/java/com/portfolio/pricing/service/ExternalPriceService.java
+++ b/backend/src/main/java/com/portfolio/pricing/service/ExternalPriceService.java
@@ -1,0 +1,238 @@
+package com.portfolio.pricing.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.portfolio.pricing.entity.Instrument;
+import com.portfolio.pricing.repository.InstrumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+/**
+ * 외부 시세 API 서비스.
+ * - 해외(미국 포함): Alpha Vantage
+ * - 국내(한국): KRX 정보데이터시스템
+ *
+ * 실패 시 MockPriceService로 자동 폴백한다.
+ */
+@Service
+@Primary
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.pricing.external", name = "enabled", havingValue = "true")
+public class ExternalPriceService implements PriceService {
+
+    private static final DateTimeFormatter YYYYMMDD = DateTimeFormatter.BASIC_ISO_DATE;
+
+    private final InstrumentRepository instrumentRepository;
+    private final MockPriceService fallbackPriceService;
+    private final ObjectMapper objectMapper;
+    private final RestTemplateBuilder restTemplateBuilder;
+
+    @Value("${app.pricing.external.alpha-vantage.base-url:https://www.alphavantage.co}")
+    private String alphaBaseUrl;
+
+    @Value("${app.pricing.external.alpha-vantage.api-key:}")
+    private String alphaApiKey;
+
+    @Value("${app.pricing.external.krx.base-url:http://data.krx.co.kr}")
+    private String krxBaseUrl;
+
+    @Value("${app.pricing.external.timeout-ms:3000}")
+    private long timeoutMs;
+
+    private RestTemplate restTemplate() {
+        return restTemplateBuilder
+                .setConnectTimeout(Duration.ofMillis(timeoutMs))
+                .setReadTimeout(Duration.ofMillis(timeoutMs))
+                .build();
+    }
+
+    @Override
+    public BigDecimal getCurrentPrice(String instrumentId) {
+        return resolveInstrument(instrumentId)
+                .map(instrument -> fetchExternalCurrentPrice(instrument, instrumentId)
+                        .orElseGet(() -> fallbackPriceService.getCurrentPrice(instrumentId)))
+                .orElseGet(() -> fallbackPriceService.getCurrentPrice(instrumentId));
+    }
+
+    @Override
+    public Map<String, BigDecimal> getCurrentPrices(Iterable<String> instrumentIds) {
+        Map<String, BigDecimal> prices = new LinkedHashMap<>();
+        for (String id : instrumentIds) {
+            prices.put(id, getCurrentPrice(id));
+        }
+        return prices;
+    }
+
+    @Override
+    public Optional<BigDecimal> getHistoricalPrice(String instrumentId, LocalDate date) {
+        return resolveInstrument(instrumentId)
+                .flatMap(inst -> fetchAlphaHistoricalPrice(inst.getTicker(), date))
+                .or(() -> fallbackPriceService.getHistoricalPrice(instrumentId, date));
+    }
+
+    @Override
+    public Map<LocalDate, BigDecimal> getHistoricalPrices(String instrumentId, LocalDate from, LocalDate to) {
+        Optional<Instrument> instrument = resolveInstrument(instrumentId);
+        if (instrument.isEmpty()) {
+            return fallbackPriceService.getHistoricalPrices(instrumentId, from, to);
+        }
+
+        Optional<Map<LocalDate, BigDecimal>> external = fetchAlphaHistoricalPrices(instrument.get().getTicker(), from, to);
+        return external.orElseGet(() -> fallbackPriceService.getHistoricalPrices(instrumentId, from, to));
+    }
+
+    @Override
+    public BigDecimal getFxRate(String fromCurrency, String toCurrency) {
+        if (Objects.equals(fromCurrency, toCurrency)) {
+            return BigDecimal.ONE;
+        }
+
+        try {
+            String pair = fromCurrency + toCurrency;
+            String url = alphaBaseUrl + "/query?function=CURRENCY_EXCHANGE_RATE&from_currency=" + fromCurrency
+                    + "&to_currency=" + toCurrency + "&apikey=" + alphaApiKey;
+
+            String body = restTemplate().getForObject(url, String.class);
+            JsonNode root = objectMapper.readTree(body);
+            String rate = root.path("Realtime Currency Exchange Rate")
+                    .path("5. Exchange Rate")
+                    .asText(null);
+            if (rate != null && !rate.isBlank()) {
+                return new BigDecimal(rate).setScale(6, RoundingMode.HALF_UP);
+            }
+        } catch (Exception e) {
+            log.warn("Alpha Vantage FX fetch failed: {}->{}, fallback mock. cause={}", fromCurrency, toCurrency, e.getMessage());
+        }
+        return fallbackPriceService.getFxRate(fromCurrency, toCurrency);
+    }
+
+    private Optional<BigDecimal> fetchExternalCurrentPrice(Instrument instrument, String instrumentId) {
+        try {
+            boolean isKoreanStock = "KR".equalsIgnoreCase(instrument.getCountry())
+                    || (instrument.getTicker() != null && instrument.getTicker().matches("\\d{6}"));
+            if (isKoreanStock) {
+                return fetchKrxCurrentPrice(instrument.getTicker());
+            }
+            return fetchAlphaCurrentPrice(instrument.getTicker());
+        } catch (Exception e) {
+            log.warn("External price fetch failed for instrument={}, ticker={}, cause={}",
+                    instrumentId, instrument.getTicker(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<BigDecimal> fetchAlphaCurrentPrice(String ticker) {
+        if (ticker == null || ticker.isBlank() || alphaApiKey == null || alphaApiKey.isBlank()) {
+            return Optional.empty();
+        }
+        String url = alphaBaseUrl + "/query?function=GLOBAL_QUOTE&symbol=" + ticker + "&apikey=" + alphaApiKey;
+        String body = restTemplate().getForObject(url, String.class);
+        JsonNode root = objectMapper.readTree(body);
+        String rawPrice = root.path("Global Quote").path("05. price").asText(null);
+        if (rawPrice == null || rawPrice.isBlank()) return Optional.empty();
+
+        return Optional.of(new BigDecimal(rawPrice).setScale(2, RoundingMode.HALF_UP));
+    }
+
+    private Optional<BigDecimal> fetchKrxCurrentPrice(String ticker) {
+        if (ticker == null || ticker.isBlank()) return Optional.empty();
+
+        String url = krxBaseUrl + "/comm/bldAttendant/getJsonData.cmd";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("bld", "dbms/MDC/STAT/standard/MDCSTAT01501");
+        form.add("locale", "ko_KR");
+        form.add("isuCd", ticker);
+        form.add("isuCd2", ticker);
+        form.add("strtDd", LocalDate.now().minusDays(5).format(YYYYMMDD));
+        form.add("endDd", LocalDate.now().format(YYYYMMDD));
+        form.add("share", "1");
+        form.add("money", "1");
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(form, headers);
+        ResponseEntity<String> response = restTemplate().exchange(url, HttpMethod.POST, entity, String.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            return Optional.empty();
+        }
+
+        JsonNode root = objectMapper.readTree(response.getBody());
+        JsonNode outBlock = root.path("OutBlock_1");
+        if (!outBlock.isArray() || outBlock.isEmpty()) {
+            return Optional.empty();
+        }
+
+        JsonNode last = outBlock.get(outBlock.size() - 1);
+        String closePrice = Optional.ofNullable(last.path("TDD_CLSPRC").asText(null))
+                .orElse(last.path("CLSPRC").asText(null));
+
+        if (closePrice == null || closePrice.isBlank()) return Optional.empty();
+        String normalized = closePrice.replace(",", "").trim();
+        return Optional.of(new BigDecimal(normalized));
+    }
+
+    private Optional<BigDecimal> fetchAlphaHistoricalPrice(String ticker, LocalDate date) {
+        return fetchAlphaHistoricalPrices(ticker, date, date).map(map -> map.get(date));
+    }
+
+    private Optional<Map<LocalDate, BigDecimal>> fetchAlphaHistoricalPrices(String ticker, LocalDate from, LocalDate to) {
+        if (ticker == null || ticker.isBlank() || alphaApiKey == null || alphaApiKey.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            String url = alphaBaseUrl + "/query?function=TIME_SERIES_DAILY_ADJUSTED&outputsize=full&symbol="
+                    + ticker + "&apikey=" + alphaApiKey;
+            String body = restTemplate().getForObject(url, String.class);
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode series = root.path("Time Series (Daily)");
+            if (!series.isObject()) return Optional.empty();
+
+            Map<LocalDate, BigDecimal> result = new LinkedHashMap<>();
+            LocalDate cursor = from;
+            while (!cursor.isAfter(to)) {
+                JsonNode daily = series.path(cursor.toString());
+                if (!daily.isMissingNode()) {
+                    String close = daily.path("5. adjusted close").asText(null);
+                    if (close == null || close.isBlank()) {
+                        close = daily.path("4. close").asText(null);
+                    }
+                    if (close != null && !close.isBlank()) {
+                        result.put(cursor, new BigDecimal(close).setScale(2, RoundingMode.HALF_UP));
+                    }
+                }
+                cursor = cursor.plusDays(1);
+            }
+
+            return result.isEmpty() ? Optional.empty() : Optional.of(result);
+        } catch (Exception e) {
+            log.warn("Alpha historical fetch failed: ticker={}, cause={}", ticker, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<Instrument> resolveInstrument(String instrumentId) {
+        Optional<Instrument> byId = instrumentRepository.findById(instrumentId);
+        if (byId.isPresent()) return byId;
+        return instrumentRepository.findByTicker(instrumentId);
+    }
+}

--- a/backend/src/main/resources/api-keys.example.yml
+++ b/backend/src/main/resources/api-keys.example.yml
@@ -1,0 +1,5 @@
+# Copy this file to `api-keys.yml` and fill your private keys.
+# `api-keys.yml` is gitignored.
+api:
+  keys:
+    alpha-vantage: your_alpha_vantage_api_key

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -84,6 +84,14 @@ app:
   pricing:
     poll-interval: 15000
     retry-max-attempts: 3
+    external:
+      enabled: ${EXTERNAL_PRICING_ENABLED:false}
+      timeout-ms: ${EXTERNAL_PRICING_TIMEOUT_MS:3000}
+      alpha-vantage:
+        api-key: ${ALPHA_VANTAGE_API_KEY:${api.keys.alpha-vantage:}}
+        base-url: ${ALPHA_VANTAGE_BASE_URL:https://www.alphavantage.co}
+      krx:
+        base-url: ${KRX_BASE_URL:http://data.krx.co.kr}
 
   backtest:
     queue-name: backtest-jobs

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: portfolio-api
 
+  config:
+    import: optional:classpath:api-keys.yml
+
   profiles:
     active: local
 
@@ -87,6 +90,14 @@ app:
   pricing:
     poll-interval: 15000  # milliseconds
     retry-max-attempts: 3
+    external:
+      enabled: ${EXTERNAL_PRICING_ENABLED:false}
+      timeout-ms: ${EXTERNAL_PRICING_TIMEOUT_MS:3000}
+      alpha-vantage:
+        api-key: ${ALPHA_VANTAGE_API_KEY:${api.keys.alpha-vantage:}}
+        base-url: ${ALPHA_VANTAGE_BASE_URL:https://www.alphavantage.co}
+      krx:
+        base-url: ${KRX_BASE_URL:http://data.krx.co.kr}
 
   backtest:
     queue-name: backtest-jobs


### PR DESCRIPTION
### Motivation
- Keep private API keys out of source control and provide a local, gitignored option for storing external pricing API keys. 
- Allow deployments to use either environment variables or a local properties file for Alpha Vantage credentials so existing workflows are not disrupted. 

### Description
- Added optional Spring config import `spring.config.import=optional:classpath:api-keys.yml` and updated `app.pricing.external.alpha-vantage.api-key` to resolve from `ALPHA_VANTAGE_API_KEY` or `api.keys.alpha-vantage`. 
- Added `backend/src/main/resources/api-keys.example.yml` as a tracked template for local key configuration and updated `application.yml` and `application-dev.yml` to support the new lookup. 
- Updated `.gitignore` and `backend/.gitignore` to ignore `backend/src/main/resources/api-keys.yml` (local secret file) and updated `README.md` with instructions to copy the example file or use environment variables. 
- The repo also contains the new `ExternalPriceService` implementation for external pricing (Alpha Vantage / KRX) which uses the configured key lookup and falls back to the mock provider on failure. 

### Testing
- Attempted to run Gradle (`./gradlew help`) in this environment and the build failed due to a JDK/Gradle compatibility error: `Unsupported class file major version 69`. 
- No new automated unit tests were added as part of this change and runtime behavior falls back to the existing `MockPriceService` when external calls or keys are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ec8bccb988324b7ecfe2c100520ee)